### PR TITLE
Add `chip` argument to new_vertex.

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -82,8 +82,11 @@ vertices::
     ...         for vertex in vertices]
 
 By default, the vertices and nets we've defined will be automatically placed
-and routed in the SpiNNaker machine before we run the experiment. For greater
-control over this process, see :py:meth:`~Experiment.place_and_route`.
+and routed in the SpiNNaker machine before we run the experiment.  To manually
+specify which chip each vertex is added to, see the ``chip`` argument to
+:py:meth:`~Experiment.new_vertex`. For greater control over the place and route
+process, see :py:meth:`~Experiment.place_and_route`.
+
 
 Controling packet generation
 ----------------------------

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -730,6 +730,28 @@ def test_construct_vertex_commands(router_access_vertex):
             assert ref_cmd1 not in commands
 
 
+def test_vertex_chip():
+    # Make sure specifying the location of each vertex works
+    mock_mc = Mock()
+    mock_mc.get_machine.return_value = Machine(2, 2)
+
+    e = Experiment(mock_mc)
+
+    v00 = e.new_vertex(chip=(0, 0))
+    v01 = e.new_vertex(chip=(0, 1))
+    v10 = e.new_vertex(chip=(1, 0))
+    v11 = e.new_vertex(chip=(1, 1))
+
+    e.place_and_route()
+
+    assert e.placements == {
+        v00: (0, 0),
+        v01: (0, 1),
+        v10: (1, 0),
+        v11: (1, 1),
+    }
+
+
 @pytest.mark.parametrize("reinjection_used", [True, False])
 def test_add_router_recording_vertices(reinjection_used):
     # Make sure this internal utility adds extra vertices only when required.


### PR DESCRIPTION
Avoids the need to messily hand-write the placements dictionary...
